### PR TITLE
[AP-695] Implement log based using DB-level ChangeStreams

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,8 @@ Create json file called `config.json`, with the following contents:
   "user": "<username>",
   "host": "<host ip address>",
   "port": "<port>",
-  "database": "<database name>"
+  "auth_database": "<database name to authenticate on>",
+  "database": "<database name to sync from>"
 }
 ```
 The following parameters are optional for your config file:
@@ -87,11 +88,6 @@ To select a stream, enter the following to the stream's metadata:
 `<replication-method>` must be either `FULL_TABLE`, `INCREMENTAL` or `LOG_BASED`, if it's `INCREMENTAL`, make sure to add a `"replication-key"`.
 
 
-To add a projection to a stream, add the following to the stream's metadata field:
-```json
-"pipelinewise-tap-mongodb.projection": <projection>
-```
-
 For example, if you were to edit the example stream to select the stream as well as add a projection, config.json should look this:
 ```json
 {
@@ -113,8 +109,7 @@ For example, if you were to edit the example stream to select the stream as well
               "_id"
             ],
             "selected": true,
-            "replication-method": "<replication method>",
-            "pipelinewise-tap-mongodb.projection": "<projection>"
+            "replication-method": "<replication method>"
           }
         }
       ],

--- a/sample_config.json
+++ b/sample_config.json
@@ -3,7 +3,8 @@
   "user": "<username>",
   "host": "<host ip address>",
   "port": "<port>",
-  "database": "<database name>",
+  "auth_database": "<database to authenticate on>",
+  "database": "<collection database name>",
   "replica_set": "<replicaSet name if exist, null otherwise>",
   "verify_mode": "<SSL verify mode | optional, default 'true'>",
   "ssl": "<enable SSL | optional>"

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -3,21 +3,20 @@ import copy
 import json
 import ssl
 import sys
+from typing import List, Dict
+
 import singer
-
-from typing import List, Dict, Optional
 from pymongo import MongoClient
-from json import JSONDecodeError
-
-from pymongo.collection import Collection
-from pymongo.database import Database
 from singer import metadata, metrics, utils
 
+import tap_mongodb.sync_strategies.change_streams as change_streams
 import tap_mongodb.sync_strategies.common as common
 import tap_mongodb.sync_strategies.full_table as full_table
 import tap_mongodb.sync_strategies.incremental as incremental
-import tap_mongodb.sync_strategies.change_streams as change_streams
-from tap_mongodb.errors import InvalidReplicationMethodException, InvalidProjectionException
+from tap_mongodb.db_utils import get_databases, produce_collection_schema
+from tap_mongodb.errors import InvalidReplicationMethodException, NoReadPrivilegeException
+from tap_mongodb.stream_utils import is_log_based_stream, is_stream_selected, write_schema_message, \
+    streams_list_to_dict, filter_streams_by_replication_method, get_streams_to_sync
 
 LOGGER = singer.get_logger('tap_mongodb')
 
@@ -26,194 +25,20 @@ REQUIRED_CONFIG_KEYS = [
     'port',
     'user',
     'password',
+    'auth_database',
     'database'
 ]
 
-IGNORE_DBS = ['system', 'local', 'config']
-ROLES_WITHOUT_FIND_PRIVILEGES = {
-    'dbAdmin',
-    'userAdmin',
-    'clusterAdmin',
-    'clusterManager',
-    'clusterMonitor',
-    'hostManager',
-    'restore'
-}
-ROLES_WITH_FIND_PRIVILEGES = {
-    'read',
-    'readWrite',
-    'readAnyDatabase',
-    'readWriteAnyDatabase',
-    'dbOwner',
-    'backup',
-    'root'
-}
-ROLES_WITH_ALL_DB_FIND_PRIVILEGES = {
-    'readAnyDatabase',
-    'readWriteAnyDatabase',
-    'root'
-}
-
-
-def get_roles_with_find_privs(database: Database, user: Dict) -> List[Dict]:
-    """
-    Finds and returns all the user's roles that have find privileges.
-    User is dictionary in the form:
-     {
-         '_id': <auth_db>.<user>,
-         'db': <auth_db>,
-         'mechanisms': ['SCRAM-SHA-1', 'SCRAM-SHA-256'],
-         'roles': [{'db': 'admin', 'role': 'readWriteAnyDatabase'},
-                   {'db': 'local', 'role': 'read'}],
-         'user': <user>,
-         'userId': <userId>
-     }
-    Args:
-        database: MongoDB Database instance
-        user: db user dictionary
-
-    Returns: list of roles
-
-    """
-    roles = []
-
-    for role in user.get('roles', []):
-        if role.get('role') in ROLES_WITHOUT_FIND_PRIVILEGES:
-            continue
-
-        role_name = role['role']
-
-        # roles with find privileges
-        if role_name in ROLES_WITH_FIND_PRIVILEGES and role.get('db'):
-            roles.append(role)
-
-        # for custom roles, get the "sub-roles"
-        else:
-            role_info_list = database.command({'rolesInfo': {'role': role_name, 'db': database.name}})
-            role_info = [r for r in role_info_list.get('roles', []) if r['role'] == role_name]
-
-            if len(role_info) != 1:
-                continue
-
-            roles.extend([sub_role for sub_role in role_info[0].get('roles', [])
-                          if sub_role.get('role') in ROLES_WITH_FIND_PRIVILEGES and sub_role.get('db')])
-
-    return roles
-
-
-def get_roles(database: Database, db_user: str) -> List[Dict]:
-    """
-    Get all user's roles with find privileges if user exists
-    Args:
-        database: MongoDB DB instance
-        db_user: DB user name to get roles for
-
-    Returns: List of roles found
-
-    """
-
-    # usersInfo Command  returns object in shape:
-    # {
-    #   < some_other_keys >
-    #   'users': [
-    #                {
-    #                    '_id': < auth_db >. < user >,
-    #                    'db': < auth_db >,
-    #                    'mechanisms': ['SCRAM-SHA-1', 'SCRAM-SHA-256'],
-    #                     'roles': [{'db': 'admin', 'role': 'readWriteAnyDatabase'},
-    #                               {'db': 'local', 'role': 'read'}],
-    #                     'user': < user >,
-    #                     'userId': < userId >
-    #                 }
-    #           ]
-    # }
-    user_info = database.command({'usersInfo': db_user})
-
-    users = [u for u in user_info.get('users') if u.get('user') == db_user]
-    if len(users) != 1:
-        LOGGER.warning('Could not find any users for %s', db_user)
-        return []
-
-    return get_roles_with_find_privs(database, users[0])
-
-
-def get_databases(client: MongoClient, config: Dict) -> List[str]:
-    """
-    Get all the databases in the cluster that the user roles can read from
-    Args:
-        client: MongoDB client instance
-        config: DB config
-
-    Returns: List of db names
-
-    """
-    roles = get_roles(client[config['database']], config['user'])
-    LOGGER.info('Roles: %s', roles)
-
-    can_read_all = len([role for role in roles
-                        if role['role'] in ROLES_WITH_ALL_DB_FIND_PRIVILEGES]) > 0
-
-    if can_read_all:
-        db_names = [d for d in client.list_database_names() if d not in IGNORE_DBS]
-    else:
-        db_names = [role['db'] for role in roles if role['db'] not in IGNORE_DBS]
-
-    LOGGER.info('Datbases: %s', db_names)
-
-    return db_names
-
-
-def produce_collection_schema(collection: Collection) -> Dict:
-    """
-    Generate a schema/catalog from the collection details for discovery mode
-    Args:
-        collection: stream Collection
-
-    Returns: collection catalog
-
-    """
-    collection_name = collection.name
-    collection_db_name = collection.database.name
-
-    is_view = collection.options().get('viewOn') is not None
-
-    mdata = {}
-    mdata = metadata.write(mdata, (), 'table-key-properties', ['_id'])
-    mdata = metadata.write(mdata, (), 'database-name', collection_db_name)
-    mdata = metadata.write(mdata, (), 'row-count', collection.estimated_document_count())
-    mdata = metadata.write(mdata, (), 'is-view', is_view)
-
-    # write valid-replication-key metadata by finding fields that have indexes on them.
-    # cannot get indexes for views -- NB: This means no key-based incremental for views?
-    if not is_view:
-        valid_replication_keys = []
-        coll_indexes = collection.index_information()
-        # index_information() returns a map of index_name -> index_information
-        for _, index_info in coll_indexes.items():
-            # we don't support compound indexes
-            if len(index_info.get('key')) == 1:
-                index_field_info = index_info.get('key')[0]
-                # index_field_info is a tuple of (field_name, sort_direction)
-                if index_field_info:
-                    valid_replication_keys.append(index_field_info[0])
-
-        if valid_replication_keys:
-            mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
-
-    return {
-        'table_name': collection_name,
-        'stream': collection_name,
-        'metadata': metadata.to_list(mdata),
-        'tap_stream_id': "{}-{}".format(collection_db_name, collection_name),
-        'schema': {
-            'type': 'object'
-        }
-    }
+LOG_BASED_METHOD = 'LOG_BASED'
+INCREMENTAL_METHOD = 'INCREMENTAL'
+FULL_TABLE_METHOD = 'FULL_TABLE'
 
 
 def do_discover(client: MongoClient, config: Dict):
     """
-    Run discovery mode where the mongodb cluster is scanned and all the collections are turned into streams
+    Run discovery mode where the mongodb cluster is scanned and
+    all the collections of the database in config
+    are turned into streams.
     The result is dumped to stdout as json
     Args:
         client:MongoDB Client instance
@@ -221,123 +46,26 @@ def do_discover(client: MongoClient, config: Dict):
     """
     streams = []
 
-    for db_name in get_databases(client, config):
-        database = client[db_name]
+    if config['database'] not in get_databases(client, config):
+        raise NoReadPrivilegeException(config['user'], config['database'])
 
-        collection_names = database.list_collection_names()
-        for collection_name in [c for c in collection_names
-                                if not c.startswith("system.")]:
+    database = client[config['database']]
 
-            collection = database[collection_name]
-            is_view = collection.options().get('viewOn') is not None
+    collection_names = database.list_collection_names()
 
-            # Add support for views if needed here
-            if is_view:
-                continue
+    for collection_name in [c for c in collection_names if not c.startswith("system.")]:
 
-            LOGGER.info("Getting collection info for db: %s, collection: %s",
-                        db_name, collection_name)
-            streams.append(produce_collection_schema(collection))
+        collection = database[collection_name]
+        is_view = collection.options().get('viewOn') is not None
+
+        # Add support for views if needed here
+        if is_view:
+            continue
+
+        LOGGER.info("Getting collection info for db '%s', collection '%s'", database.name, collection_name)
+        streams.append(produce_collection_schema(collection))
 
     json.dump({'streams': streams}, sys.stdout, indent=2)
-
-
-def is_stream_selected(stream: Dict) -> bool:
-    """
-    Checks the stream's metadata to see if stream is selected for sync
-    Args:
-        stream: stream dictionary
-
-    Returns: True if selected, False otherwise
-
-    """
-    mdata = metadata.to_map(stream['metadata'])
-    is_selected = metadata.get(mdata, (), 'selected')
-
-    return is_selected is True
-
-
-def get_streams_to_sync(streams: List[Dict], state: Dict) -> List:
-    """
-    Filter the streams list to return only those selected for sync
-    Args:
-        streams: list of all discovered streams
-        state: streams state
-
-    Returns: list of selected streams, ordered from streams without state to those with state
-
-    """
-    # get selected streams
-    selected_streams = [stream for stream in streams if is_stream_selected(stream)]
-
-    # prioritize streams that have not been processed
-    streams_with_state = []
-    streams_without_state = []
-
-    for stream in selected_streams:
-        if state.get('bookmarks', {}).get(stream['tap_stream_id']):
-            streams_with_state.append(stream)
-        else:
-            streams_without_state.append(stream)
-
-    ordered_streams = streams_without_state + streams_with_state
-
-    # If the state says we were in the middle of processing a stream, skip
-    # to that stream. Then process streams without prior state and finally
-    # move onto streams with state (i.e. have been synced in the past)
-    currently_syncing = singer.get_currently_syncing(state)
-
-    if currently_syncing:
-        currently_syncing_stream = list(filter(
-            lambda s: s['tap_stream_id'] == currently_syncing,
-            ordered_streams))
-        non_currently_syncing_streams = list(filter(lambda s: s['tap_stream_id'] != currently_syncing, ordered_streams))
-
-        streams_to_sync = currently_syncing_stream + non_currently_syncing_streams
-    else:
-        streams_to_sync = ordered_streams
-
-    return streams_to_sync
-
-
-def write_schema_message(stream: Dict):
-    """
-    Creates and writes a schema message to stdout
-    Args:
-        stream: stream catalog
-    """
-    singer.write_message(singer.SchemaMessage(
-        stream=common.calculate_destination_stream_name(stream),
-        schema=stream['schema'],
-        key_properties=['_id']))
-
-
-def load_stream_projection(stream: Dict) -> Optional[Dict]:
-    """
-    Looks for pre defined projection in the stream metadata
-    Args:
-        stream: stream catalog
-
-    Returns: projection if found
-
-    """
-    md_map = metadata.to_map(stream['metadata'])
-    stream_projection = metadata.get(md_map, (), 'pipelinewise-tap-mongodb.projection')
-    if stream_projection == '' or stream_projection == '""' or not stream_projection:
-        return None
-
-    try:
-        stream_projection = json.loads(stream_projection)
-    except (JSONDecodeError, TypeError):
-        err_msg = f"The projection: {stream_projection} for stream {stream['tap_stream_id']} is not valid json"
-        raise InvalidProjectionException(err_msg)
-
-    if stream_projection and stream_projection.get('_id') == 0:
-        raise InvalidProjectionException(
-            "Projection blacklists key property id for collection {}" \
-                .format(stream['tap_stream_id']))
-
-    return stream_projection
 
 
 def clear_state_on_replication_change(stream: Dict, state: Dict) -> Dict:
@@ -376,7 +104,7 @@ def clear_state_on_replication_change(stream: Dict, state: Dict) -> Dict:
     return state
 
 
-def sync_stream(client: MongoClient, stream: Dict, state: Dict):
+def sync_traditional_stream(client: MongoClient, stream: Dict, state: Dict):
     """
     Sync given stream
     Args:
@@ -393,9 +121,12 @@ def sync_stream(client: MongoClient, stream: Dict, state: Dict):
 
     md_map = metadata.to_map(stream['metadata'])
     replication_method = metadata.get(md_map, (), 'replication-method')
-    database_name = metadata.get(md_map, (), 'database-name')
 
-    stream_projection = load_stream_projection(stream)
+    if replication_method not in {INCREMENTAL_METHOD, FULL_TABLE_METHOD}:
+        raise InvalidReplicationMethodException(replication_method,
+                                                'replication method needs to be either FULL_TABLE or INCREMENTAL')
+
+    database_name = metadata.get(md_map, (), 'database-name')
 
     # Emit a state message to indicate that we've started this stream
     state = clear_state_on_replication_change(stream, state)
@@ -411,44 +142,92 @@ def sync_stream(client: MongoClient, stream: Dict, state: Dict):
 
         collection = client[database_name][stream["table_name"]]
 
-        if replication_method == 'LOG_BASED':
-            change_streams.sync_collection(collection, stream, state, stream_projection)
-
-        elif replication_method == 'FULL_TABLE':
-            full_table.sync_collection(collection, stream, state, stream_projection)
-
-        elif replication_method == 'INCREMENTAL':
-            incremental.sync_collection(collection, stream, state, stream_projection)
-
+        if replication_method == 'FULL_TABLE':
+            full_table.sync_collection(collection, stream, state)
         else:
-            raise InvalidReplicationMethodException(
-                replication_method, "Only FULL_TABLE, LOG_BASED, and INCREMENTAL replication methods are supported")
+            incremental.sync_collection(collection, stream, state)
 
     state = singer.set_currently_syncing(state, None)
 
     singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
 
 
-def do_sync(client: MongoClient, catalog: Dict, state: Dict):
+
+def sync_traditional_streams(client: MongoClient, traditional_streams: List[Dict], state: Dict):
+    """
+    Sync traditional streams that use either FULL_TABLE or INCREMENTAL one stream at a time.
+    Args:
+        client: MongoDB client instance
+        traditional_streams: list of streams to sync
+        state: state dictionary
+    """
+    for stream in traditional_streams:
+        sync_traditional_stream(client, stream, state)
+
+
+def sync_log_based_streams(client: MongoClient, log_based_streams: List[Dict], database_name: str, state: Dict):
+    """
+    Sync log_based streams all at once by listening on the database-level change streams events.
+    Args:
+        client: MongoDB client instance
+        log_based_streams:  list of streams to sync
+        database_name: name of the database to sync from
+        state: state dictionary
+    """
+    if not log_based_streams:
+        return
+
+    streams = streams_list_to_dict(log_based_streams)
+
+    for tap_stream_id, stream in streams.items():
+        common.COUNTS[tap_stream_id] = 0
+        common.TIMES[tap_stream_id] = 0
+        common.SCHEMA_COUNT[tap_stream_id] = 0
+        common.SCHEMA_TIMES[tap_stream_id] = 0
+
+        state = clear_state_on_replication_change(stream, state)
+        singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+        write_schema_message(stream)
+        common.SCHEMA_COUNT[tap_stream_id] += 1
+
+    with metrics.job_timer('sync_table') as timer:
+        timer.tags['database'] = database_name
+
+        change_streams.sync_database(client[database_name], streams, state)
+
+    state = singer.set_currently_syncing(state, None)
+    singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))
+
+
+def do_sync(client: MongoClient, catalog: Dict, database_name: str, state: Dict):
     """
     Syncs all the selected streams in the catalog
     Args:
         client: MongoDb client instance
         catalog: dictionary with all the streams details
+        database_name: name of the database to sync from
         state: state
     """
     all_streams = catalog['streams']
     streams_to_sync = get_streams_to_sync(all_streams, state)
 
-    for stream in streams_to_sync:
-        sync_stream(client, stream, state)
+    log_based_streams, traditional_streams = filter_streams_by_replication_method(streams_to_sync)
+
+    LOGGER.debug('Starting sync of traditional streams ...')
+    sync_traditional_streams(client, traditional_streams, state)
+    LOGGER.debug('Sync of traditional streams done')
+
+    LOGGER.debug('Starting sync of log based streams ...')
+    sync_log_based_streams(client, log_based_streams, database_name, state)
+    LOGGER.debug('Sync of log based streams done')
 
     LOGGER.info(common.get_sync_summary(catalog))
 
 
 def main_impl():
     """
-    Main method
+    Main function
     """
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
@@ -461,7 +240,7 @@ def main_impl():
                          "port": int(config['port']),
                          "username": config.get('user', None),
                          "password": config.get('password', None),
-                         "authSource": config['database'],
+                         "authSource": config['auth_database'],
                          "ssl": use_ssl,
                          "replicaSet": config.get('replica_set', None),
                          "readPreference": 'secondaryPreferred'
@@ -484,7 +263,7 @@ def main_impl():
         do_discover(client, config)
     elif args.catalog:
         state = args.state or {}
-        do_sync(client, args.catalog.to_dict(), state)
+        do_sync(client, args.catalog.to_dict(), config['database'], state)
 
 
 def main():

--- a/tap_mongodb/db_utils.py
+++ b/tap_mongodb/db_utils.py
@@ -1,0 +1,192 @@
+"""
+List of helper functions for DB related procceses only
+"""
+
+import singer
+
+from typing import Dict, List
+from pymongo import MongoClient
+from pymongo.collection import Collection
+from pymongo.database import Database
+from singer import metadata
+
+LOGGER = singer.get_logger('tap_mongodb')
+
+IGNORE_DBS = ['system', 'local', 'config']
+ROLES_WITHOUT_FIND_PRIVILEGES = {
+    'dbAdmin',
+    'userAdmin',
+    'clusterAdmin',
+    'clusterManager',
+    'clusterMonitor',
+    'hostManager',
+    'restore'
+}
+ROLES_WITH_FIND_PRIVILEGES = {
+    'read',
+    'readWrite',
+    'readAnyDatabase',
+    'readWriteAnyDatabase',
+    'dbOwner',
+    'backup',
+    'root'
+}
+ROLES_WITH_ALL_DB_FIND_PRIVILEGES = {
+    'readAnyDatabase',
+    'readWriteAnyDatabase',
+    'root'
+}
+
+def get_roles_with_find_privs(database: Database, user: Dict) -> List[Dict]:
+    """
+    Finds and returns all the user's roles that have find privileges.
+    User is dictionary in the form:
+     {
+         '_id': <auth_db>.<user>,
+         'db': <auth_db>,
+         'mechanisms': ['SCRAM-SHA-1', 'SCRAM-SHA-256'],
+         'roles': [{'db': 'admin', 'role': 'readWriteAnyDatabase'},
+                   {'db': 'local', 'role': 'read'}],
+         'user': <user>,
+         'userId': <userId>
+     }
+    Args:
+        database: MongoDB Database instance
+        user: db user dictionary
+
+    Returns: list of roles
+
+    """
+    roles = []
+
+    for role in user.get('roles', []):
+        if role.get('role') in ROLES_WITHOUT_FIND_PRIVILEGES:
+            continue
+
+        role_name = role['role']
+
+        # roles with find privileges
+        if role_name in ROLES_WITH_FIND_PRIVILEGES and role.get('db'):
+            roles.append(role)
+
+        # for custom roles, get the "sub-roles"
+        else:
+            role_info_list = database.command({'rolesInfo': {'role': role_name, 'db': database.name}})
+            role_info = [r for r in role_info_list.get('roles', []) if r['role'] == role_name]
+
+            if len(role_info) != 1:
+                continue
+
+            roles.extend([sub_role for sub_role in role_info[0].get('roles', [])
+                          if sub_role.get('role') in ROLES_WITH_FIND_PRIVILEGES and sub_role.get('db')])
+
+    return roles
+
+
+def get_roles(database: Database, db_user: str) -> List[Dict]:
+    """
+    Get all user's roles with find privileges if user exists
+    Args:
+        database: MongoDB DB instance
+        db_user: DB user name to get roles for
+
+    Returns: List of roles found
+
+    """
+
+    # usersInfo Command  returns object in shape:
+    # {
+    #   < some_other_keys >
+    #   'users': [
+    #                {
+    #                    '_id': < auth_db >. < user >,
+    #                    'db': < auth_db >,
+    #                    'mechanisms': ['SCRAM-SHA-1', 'SCRAM-SHA-256'],
+    #                     'roles': [{'db': 'admin', 'role': 'readWriteAnyDatabase'},
+    #                               {'db': 'local', 'role': 'read'}],
+    #                     'user': < user >,
+    #                     'userId': < userId >
+    #                 }
+    #           ]
+    # }
+    user_info = database.command({'usersInfo': db_user})
+
+    users = [u for u in user_info.get('users') if u.get('user') == db_user]
+    if len(users) != 1:
+        LOGGER.warning('Could not find any users for %s', db_user)
+        return []
+
+    return get_roles_with_find_privs(database, users[0])
+
+
+def get_databases(client: MongoClient, config: Dict) -> List[str]:
+    """
+    Get all the databases in the cluster that the user roles can read from
+    Args:
+        client: MongoDB client instance
+        config: DB config
+
+    Returns: List of db names
+
+    """
+    roles = get_roles(client[config['auth_database']], config['user'])
+    LOGGER.info('Roles: %s', roles)
+
+    can_read_all = len([role for role in roles if role['role'] in ROLES_WITH_ALL_DB_FIND_PRIVILEGES]) > 0
+
+    if can_read_all:
+        db_names = [d for d in client.list_database_names() if d not in IGNORE_DBS]
+    else:
+        db_names = [role['db'] for role in roles if role['db'] not in IGNORE_DBS]
+
+    LOGGER.info('Databases: %s', db_names)
+
+    return db_names
+
+
+def produce_collection_schema(collection: Collection) -> Dict:
+    """
+    Generate a schema/catalog from the collection details for discovery mode
+    Args:
+        collection: stream Collection
+
+    Returns: collection catalog
+
+    """
+    collection_name = collection.name
+    collection_db_name = collection.database.name
+
+    is_view = collection.options().get('viewOn') is not None
+
+    mdata = {}
+    mdata = metadata.write(mdata, (), 'table-key-properties', ['_id'])
+    mdata = metadata.write(mdata, (), 'database-name', collection_db_name)
+    mdata = metadata.write(mdata, (), 'row-count', collection.estimated_document_count())
+    mdata = metadata.write(mdata, (), 'is-view', is_view)
+
+    # write valid-replication-key metadata by finding fields that have indexes on them.
+    # cannot get indexes for views -- NB: This means no key-based incremental for views?
+    if not is_view:
+        valid_replication_keys = []
+        coll_indexes = collection.index_information()
+        # index_information() returns a map of index_name -> index_information
+        for _, index_info in coll_indexes.items():
+            # we don't support compound indexes
+            if len(index_info.get('key')) == 1:
+                index_field_info = index_info.get('key')[0]
+                # index_field_info is a tuple of (field_name, sort_direction)
+                if index_field_info:
+                    valid_replication_keys.append(index_field_info[0])
+
+        if valid_replication_keys:
+            mdata = metadata.write(mdata, (), 'valid-replication-keys', valid_replication_keys)
+
+    return {
+        'table_name': collection_name,
+        'stream': collection_name,
+        'metadata': metadata.to_list(mdata),
+        'tap_stream_id': "{}-{}".format(collection_db_name, collection_name),
+        'schema': {
+            'type': 'object'
+        }
+    }

--- a/tap_mongodb/errors.py
+++ b/tap_mongodb/errors.py
@@ -10,9 +10,6 @@ class InvalidReplicationMethodException(Exception):
         super(InvalidReplicationMethodException, self).__init__(msg)
 
 
-class InvalidProjectionException(Exception):
-    """Raised if projection blacklists _id"""
-
 class UnsupportedKeyTypeException(Exception):
     """Raised if key type is unsupported"""
 
@@ -24,3 +21,9 @@ class MongoInvalidDateTimeException(Exception):
 
 class SyncException(Exception):
     """Raised if we find an invalid date-time that we can't handle"""
+
+class NoReadPrivilegeException(Exception):
+    """Raised if the DB user has no read privilege on the DB"""
+    def __init__(self, user, db_name):
+        msg = f"The user '{user}' has no read privilege on the database '{db_name}'!"
+        super(NoReadPrivilegeException, self).__init__(msg)

--- a/tap_mongodb/stream_utils.py
+++ b/tap_mongodb/stream_utils.py
@@ -1,0 +1,135 @@
+#!/usr/bin/env python3
+"""
+List of helper functions for streams only
+"""
+
+from typing import Dict, Optional, List, Tuple
+
+import singer
+from singer import metadata, write_message, SchemaMessage
+
+from tap_mongodb.sync_strategies.common import calculate_destination_stream_name
+
+
+def get_replication_method_from_stream(stream: Dict) -> Optional[str]:
+    """
+    Search for the stream replication method
+    Args:
+        stream: stream dictionary
+
+    Returns: replication method if defined, None otherwise
+
+    """
+    md_map = metadata.to_map(stream['metadata'])
+    return metadata.get(md_map, (), 'replication-method')
+
+
+def is_log_based_stream(stream: Dict) -> bool:
+    """
+    checks if stream uses log based replication method
+    Returns: True if LOG_BASED, False otherwise
+    """
+    return get_replication_method_from_stream(stream) == 'LOG_BASED'
+
+
+def write_schema_message(stream: Dict):
+    """
+    Creates and writes a stream schema message to stdout
+    Args:
+        stream: stream catalog
+    """
+    write_message(SchemaMessage(
+        stream=calculate_destination_stream_name(stream),
+        schema=stream['schema'],
+        key_properties=['_id']))
+
+
+def is_stream_selected(stream: Dict) -> bool:
+    """
+    Checks the stream's metadata to see if stream is selected for sync
+    Args:
+        stream: stream dictionary
+
+    Returns: True if selected, False otherwise
+
+    """
+    mdata = metadata.to_map(stream['metadata'])
+    is_selected = metadata.get(mdata, (), 'selected')
+
+    return is_selected is True
+
+
+def streams_list_to_dict(streams: List[Dict]) -> Dict[str, Dict]:
+    """
+    converts the streams list to dictionary of streams where the keys are the tap stream ids
+    Args:
+        streams: stream list
+
+    Returns: dictionary od streams
+
+    """
+    return {stream['tap_stream_id']: stream for stream in streams}
+
+
+def filter_streams_by_replication_method(streams_to_sync: List[Dict]) -> Tuple[List[Dict], List[Dict]]:
+    """
+    Divides the list of streams into two lists: one of streams that use log based and the other that use
+    traditional replication method, i.e either Full table or Incremental
+    Args:
+        streams_to_sync: List of streams selected to sync
+    Returns: Tuple of two lists, first is log based streams and the second is list of traditional streams
+
+    """
+    log_based_streams = []
+    non_log_based_streams = []
+
+    for stream in streams_to_sync:
+        if is_log_based_stream(stream):
+            log_based_streams.append(stream)
+        else:
+            non_log_based_streams.append(stream)
+
+    return log_based_streams, non_log_based_streams
+
+
+def get_streams_to_sync(streams: List[Dict], state: Dict) -> List:
+    """
+    Filter the streams list to return only those selected for sync
+    Args:
+        streams: list of all discovered streams
+        state: streams state
+
+    Returns: list of selected streams, ordered from streams without state to those with state
+
+    """
+    # get selected streams
+    selected_streams = [stream for stream in streams if is_stream_selected(stream)]
+
+    # prioritize streams that have not been processed
+    streams_with_state = []
+    streams_without_state = []
+
+    for stream in selected_streams:
+        if state.get('bookmarks', {}).get(stream['tap_stream_id']):
+            streams_with_state.append(stream)
+        else:
+            streams_without_state.append(stream)
+
+    ordered_streams = streams_without_state + streams_with_state
+
+    # If the state says we were in the middle of processing a stream, skip
+    # to that stream. Then process streams without prior state and finally
+    # move onto streams with state (i.e. have been synced in the past)
+    currently_syncing = singer.get_currently_syncing(state)
+
+    if currently_syncing:
+        currently_syncing_stream = list(filter(
+            lambda s: s['tap_stream_id'] == currently_syncing,
+            ordered_streams))
+        non_currently_syncing_streams = list(filter(lambda s: s['tap_stream_id'] != currently_syncing, ordered_streams))
+
+        streams_to_sync = currently_syncing_stream + non_currently_syncing_streams
+    else:
+        streams_to_sync = ordered_streams
+
+    return streams_to_sync

--- a/tap_mongodb/sync_strategies/change_streams.py
+++ b/tap_mongodb/sync_strategies/change_streams.py
@@ -118,7 +118,7 @@ def sync_database(database: Database,
             # After MAX_AWAIT_TIME_MS has elapsed, the cursor will return None.
             # write state and exit
             if change is None:
-                LOGGER.debug('No change streams after % s, updating bookmark and exiting...', MAX_AWAIT_TIME_MS)
+                LOGGER.debug('No change streams after %s, updating bookmark and exiting...', MAX_AWAIT_TIME_MS)
 
                 state = update_bookmarks(state, stream_ids, resume_token)
                 singer.write_message(singer.StateMessage(value=copy.deepcopy(state)))

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -10,7 +10,7 @@ import singer
 import pytz
 import tzlocal
 
-from typing import Dict, Any, List
+from typing import Dict, Any, List, Optional
 from bson import objectid, timestamp, datetime as bson_datetime
 from singer import utils, metadata
 from terminaltables import AsciiTable
@@ -204,7 +204,7 @@ def transform_value(value: Any, path) -> Any:
 
 def row_to_singer_record(stream: Dict,
                          row: Dict,
-                         version: int,
+                         version: Optional[int],
                          time_extracted: datetime.datetime) -> singer.RecordMessage:
     """
     Transforms row to singer record message

--- a/tap_mongodb/sync_strategies/full_table.py
+++ b/tap_mongodb/sync_strategies/full_table.py
@@ -30,14 +30,13 @@ def get_max_id_value(collection: Collection) -> Optional[str]:
     return None
 
 
-def sync_collection(collection: Collection, stream: Dict, state: Dict, projection: Optional[str]) -> None:
+def sync_collection(collection: Collection, stream: Dict, state: Dict) -> None:
     """
     Sync collection records incrementally
     Args:
         collection: MongoDB collection instance
         stream: dictionary of all stream details
         state: the tap state
-        projection: query projection if defined
     """
     LOGGER.info('Starting full table sync for %s', stream['tap_stream_id'])
 
@@ -96,10 +95,9 @@ def sync_collection(collection: Collection, stream: Dict, state: Dict, projectio
                                                                                           stream['tap_stream_id'],
                                                                                           'last_id_fetched_type'))
 
-    LOGGER.info('Querying %s with: %s', stream['tap_stream_id'], dict(find=find_filter, projection=projection))
+    LOGGER.info('Querying %s with: %s', stream['tap_stream_id'], dict(find=find_filter))
 
     with collection.find({'_id': find_filter},
-                         projection,
                          sort=[("_id", pymongo.ASCENDING)]) as cursor:
         rows_saved = 0
         start_time = time.time()

--- a/tap_mongodb/sync_strategies/incremental.py
+++ b/tap_mongodb/sync_strategies/incremental.py
@@ -43,7 +43,6 @@ def update_bookmark(row: Dict, state: Dict, tap_stream_id: str, replication_key_
 def sync_collection(collection: Collection,
                     stream: Dict,
                     state: Optional[Dict],
-                    projection: Optional[str]
                     ) -> None:
     """
     Syncs the stream records incrementally
@@ -51,7 +50,6 @@ def sync_collection(collection: Collection,
         collection: MongoDB collection instance
         stream: stream dictionary
         state: state dictionary if exists
-        projection: projection for querying if exists
     """
     LOGGER.info('Starting incremental sync for %s', stream['tap_stream_id'])
 
@@ -96,13 +94,12 @@ def sync_collection(collection: Collection,
                                                                            stream_state.get('replication_key_type'))
 
     # log query
-    LOGGER.info('Querying %s with: %s', stream['tap_stream_id'], dict(find=find_filter, projection=projection))
+    LOGGER.info('Querying %s with: %s', stream['tap_stream_id'], dict(find=find_filter))
 
     # query collection
     schema = {"type": "object", "properties": {}}
 
     with collection.find(find_filter,
-                         projection,
                          sort=[(replication_key_name, pymongo.ASCENDING)]) as cursor:
         rows_saved = 0
         start_time = time.time()


### PR DESCRIPTION
# Problem
With collection-level change streams, there is a risk of a collection being too active that other collections would never be synced.

# Solution

Refactor the log based strategy to use db-level change streams that way all the events from the selected collection can be read and then processed. 
This has the downside of having to drop two existing feature which are support sync of collections from different databases and collection projections.

These features are deemed to be unnecessary for now.

# QA steps
 - [x] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
