### PR TITLE
[AP-639] Add properties to stream schema in discovery mode

### DIFF
--- a/tap_mongodb/db_utils.py
+++ b/tap_mongodb/db_utils.py
@@ -187,6 +187,7 @@ def produce_collection_schema(collection: Collection) -> Dict:
         'metadata': metadata.to_list(mdata),
         'tap_stream_id': "{}-{}".format(collection_db_name, collection_name),
         'schema': {
-            'type': 'object'
+            'type': 'object',
+            'properties': {}
         }
     }


### PR DESCRIPTION
# Problem
import of mongo taps as well as syncing to Snowflake fails because schema is missing properties. 


# Solution
add empty properties object

# QA steps
 - [x] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
