### PR TITLE
[AP-810]  Resume tokens not JSON serializable

### DIFF
--- a/tap_mongodb/sync_strategies/change_streams.py
+++ b/tap_mongodb/sync_strategies/change_streams.py
@@ -110,7 +110,18 @@ def sync_database(database: Database,
 
             # Note that the ChangeStream's resume token may be updated
             # even when no changes are returned.
-            resume_token = cursor.resume_token
+
+            # Token can look like in MongoDB 4.2:
+            #       {'_data': 'A_LONG_HEX_DECIMAL_STRING'}
+            #    or {'_data': 'A_LONG_HEX_DECIMAL_STRING', '_typeBits': b'SOME_HEX'}
+
+            # Get the '_data' only from resume token
+            # token can contain a property '_typeBits' of type bytes which cannot be json
+            # serialized when creating the state.
+            # '_data' is enough to resume LOG_BASED
+            resume_token = {
+                '_data': cursor.resume_token['_data']
+            }
 
             change = cursor.try_next()
 

--- a/tests/sync_strategies/test_change_streams.py
+++ b/tests/sync_strategies/test_change_streams.py
@@ -271,24 +271,30 @@ class TestChangeStreams(unittest.TestCase):
         type(cursor_mock).alive = PropertyMock(return_value=True)
         type(cursor_mock).resume_token = PropertyMock(side_effect=[
             {
-                '_data': 'token1'
+                '_data': 'token1',
+                'some_extra_property': b'\x81'
             },
             {
-                '_data': 'token2'
-            },
-
-            {
-                '_data': 'token3'
-            },
-            {
-                '_data': 'token4'
+                '_data': 'token2',
+                'some_extra_property': b'\x81'
             },
 
             {
-                '_data': 'token5'
+                '_data': 'token3',
+                'some_extra_property': b'\x81'
             },
             {
-                '_data': 'token6'
+                '_data': 'token4',
+                'some_extra_property': b'\x81'
+            },
+
+            {
+                '_data': 'token5',
+                'some_extra_property': b'\x81'
+            },
+            {
+                '_data': 'token6',
+                'some_extra_property': b'\x81'
             }
         ])
 

--- a/tests/sync_strategies/test_change_streams.py
+++ b/tests/sync_strategies/test_change_streams.py
@@ -269,9 +269,29 @@ class TestChangeStreams(unittest.TestCase):
 
         cursor_mock = Mock(spec_set=CollectionChangeStream).return_value
         type(cursor_mock).alive = PropertyMock(return_value=True)
-        type(cursor_mock).resume_token = PropertyMock(side_effect=['token1', 'token2',
-                                                                   'token3', 'token4',
-                                                                   'token5', 'token6'])
+        type(cursor_mock).resume_token = PropertyMock(side_effect=[
+            {
+                '_data': 'token1'
+            },
+            {
+                '_data': 'token2'
+            },
+
+            {
+                '_data': 'token3'
+            },
+            {
+                '_data': 'token4'
+            },
+
+            {
+                '_data': 'token5'
+            },
+            {
+                '_data': 'token6'
+            }
+        ])
+
         cursor_mock.try_next.side_effect = changes
 
         mock_enter = Mock()
@@ -290,13 +310,20 @@ class TestChangeStreams(unittest.TestCase):
         self.assertEqual({
             'bookmarks': {
                 'mydb-stream1': {
-                    'token': 'token6',
+                    'token':
+                        {
+                            '_data': 'token6'
+                        },
                 },
                 'mydb-stream2': {
-                    'token': 'token6',
+                    'token': {
+                        '_data': 'token6'
+                    },
                 },
                 'mydb-stream3': {
-                    'token': 'token6',
+                    'token': {
+                        '_data': 'token6'
+                    },
                 },
                 'mydb-stream4': {
                     'token':


### PR DESCRIPTION
## Problem
In some cases, for an unknown reason, Mongodb servers generate a resume token that can look like this:

```py
{'_data': '825F167E8C000000322B022C2EC22461E5F6964002E128A18AC0004', '_typeBits': b'\x81\x80'}
```

The unexpected bytes property `_typeBits` causes replication to break as this token is not JSON serializable when creating the state message.

*Problematic server*
MongoDB sharded cluster v4.2.2-3

## Solution
Extract the `_data` hex property only and save it as the token.
Manual test against the problematic server proved this works, the server can still send in new changes streams with a token that has `_data` only.