### PR TITLE
[AP-813] & [AP-789] make some Log based params configurable 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,5 @@ test:
 	pytest tests -v; \
 
 test_cov:
-	coverage run -m pytest tests -v; \
-	coverage report --include="tap_mongodb/*";
+	pytest --cov=tap_mongodb tests -v
 

--- a/Makefile
+++ b/Makefile
@@ -27,11 +27,10 @@ setup: create_venv setup_local_db upgrade_pip install_dep check_dep
 	echo "Setup is finished"
 
 pylint:
-	pylint tap_mongodb tap_mongodb/sync_strategies --rcfile=pylintrc; \
+	pylint tap_mongodb tap_mongodb/sync_strategies --rcfile=pylintrc
 
 test:
-	pytest tests -v; \
+	pytest tests -v
 
 test_cov:
 	pytest --cov=tap_mongodb tests -v
-

--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ Create json file called `config.json`, with the following contents:
 ```
 The following parameters are optional for your config file:
 
-| Name | Type | Description |
-| -----|------|------------ |
-| `replica_set` | string | name of replica set |
-| `ssl` | Boolean | can be set to true to connect using ssl, default false |
-| `verify_mode` | Boolean | Default SSL verify mode, default true |
-| `include_schemas_in_destination_stream_name` | Boolean | forces the stream names to take the form `<database_name>-<collection_name>` instead of `<collection_name>`, default false|
+| Name | Type | Default value| Description |
+| -----|------|--------|------------ |
+| `replica_set` | string | null | name of replica set |
+| `ssl` | Boolean | false | can be set to true to connect using ssl |
+| `verify_mode` | Boolean | true | Default SSL verify mode |
+| `include_schemas_in_destination_stream_name` | Boolean |false  | forces the stream names to take the form `<database_name>-<collection_name>` instead of `<collection_name>`|
+| `update_buffer_size` | int | 1 | [LOG_BASED] The size of the buffer that holds detected update operations in memory, the buffer is flushed once the size is reached |
+| `await_time_ms` | int | 1000 | [LOG_BASED] The maximum amount of time in milliseconds the loge_base method waits for new data changes before exiting. |
 
 All of the above attributes are required by the tap to connect to your mongo instance. 
 here is a [sample configuration file](./sample_config.json).

--- a/sample_config.json
+++ b/sample_config.json
@@ -7,5 +7,7 @@
   "database": "<collection database name>",
   "replica_set": "<replicaSet name if exist, null otherwise>",
   "verify_mode": "<SSL verify mode | optional, default 'true'>",
-  "ssl": "<enable SSL | optional>"
+  "ssl": "<enable SSL | optional>",
+  "update_buffer_size": "<int>",
+  "await_time_ms": "<int>"
 }

--- a/setup.py
+++ b/setup.py
@@ -22,12 +22,11 @@ setup(name='pipelinewise-tap-mongodb',
       extras_require={
           'dev': [
               'pylint',
-              'nose',
               'ipdb'
           ],
           'test': [
-              'pytest',
-              'coverage'
+              'pytest==5.4',
+              'pytest-cov==2.10'
           ]
       },
       entry_points='''

--- a/tap_mongodb/config_utils.py
+++ b/tap_mongodb/config_utils.py
@@ -1,0 +1,40 @@
+from typing import Dict
+
+from tap_mongodb.errors import InvalidAwaitTimeError, InvalidUpdateBufferSizeError
+from tap_mongodb.sync_strategies import change_streams
+
+
+def validate_config(config: Dict) -> None:
+    """
+    Goes through the config and validate it
+    Currently, only few parameters are validated
+    Args:
+        config: Dictionary of config to validate
+
+    Returns: None
+    Raises: InvalidUpdateBufferSizeError or InvalidAwaitTimeError
+    """
+    if 'update_buffer_size' in config:
+        update_buffer_size = config['update_buffer_size']
+
+        if not isinstance(update_buffer_size, int):
+            raise InvalidUpdateBufferSizeError(update_buffer_size, 'Not integer')
+
+        if not (change_streams.MIN_UPDATE_BUFFER_LENGTH <=
+                update_buffer_size <= change_streams.MAX_UPDATE_BUFFER_LENGTH):
+
+            raise InvalidUpdateBufferSizeError(
+                update_buffer_size,
+                f'Not in the range [{change_streams.MIN_UPDATE_BUFFER_LENGTH}..'
+                f'{change_streams.MAX_UPDATE_BUFFER_LENGTH}]')
+
+
+    if 'await_time_ms' in config:
+        await_time_ms = config['await_time_ms']
+
+        if not isinstance(await_time_ms, int):
+            raise InvalidAwaitTimeError(await_time_ms, 'Not integer')
+
+        if await_time_ms <= 0:
+            raise InvalidAwaitTimeError(
+                await_time_ms, 'time must be > 0')

--- a/tap_mongodb/errors.py
+++ b/tap_mongodb/errors.py
@@ -27,3 +27,15 @@ class NoReadPrivilegeException(Exception):
     def __init__(self, user, db_name):
         msg = f"The user '{user}' has no read privilege on the database '{db_name}'!"
         super(NoReadPrivilegeException, self).__init__(msg)
+
+class InvalidUpdateBufferSizeError(Exception):
+    """Raised if the given update buffer size used in log_based is invalid"""
+    def __init__(self, size, reason):
+        msg = f"Invalid update buffer size {size}! {reason}"
+        super(InvalidUpdateBufferSizeError, self).__init__(msg)
+
+class InvalidAwaitTimeError(Exception):
+    """Raised if the given await time used in log_based is invalid"""
+    def __init__(self, time_ms, reason):
+        msg = f"Invalid await time {time_ms}! {reason}"
+        super(InvalidAwaitTimeError, self).__init__(msg)

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -74,7 +74,7 @@ def class_to_string(key_value: Any, key_type: str) -> str:
             local_datetime = timezone.localize(key_value)
             utc_datetime = local_datetime.astimezone(pytz.UTC)
         else:
-            utc_datetime = key_value.replace(tzinfo=pytz.UTC)
+            utc_datetime = key_value.astimezone(pytz.UTC)
 
         return utils.strftime(utc_datetime)
 

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -69,9 +69,13 @@ def class_to_string(key_value: Any, key_type: str) -> str:
     Raises: UnsupportedKeyTypeException if key_type is not supported
     """
     if key_type == 'datetime':
-        timezone = tzlocal.get_localzone()
-        local_datetime = timezone.localize(key_value)
-        utc_datetime = local_datetime.astimezone(pytz.UTC)
+        if key_value.tzinfo is None:
+            timezone = tzlocal.get_localzone()
+            local_datetime = timezone.localize(key_value)
+            utc_datetime = local_datetime.astimezone(pytz.UTC)
+        else:
+            utc_datetime = key_value.replace(tzinfo=pytz.UTC)
+
         return utils.strftime(utc_datetime)
 
     if key_type == 'Timestamp':

--- a/tests/sync_strategies/test_change_streams.py
+++ b/tests/sync_strategies/test_change_streams.py
@@ -1,8 +1,8 @@
 import unittest
-from datetime import datetime
-
 import bson
+import pytz
 
+from datetime import datetime
 from unittest.mock import patch, Mock, PropertyMock, MagicMock
 from pymongo.change_stream import CollectionChangeStream, ChangeStream
 from pymongo.collection import Collection
@@ -14,6 +14,8 @@ from tap_mongodb.sync_strategies import common
 
 
 class TestChangeStreams(unittest.TestCase):
+
+    maxDiff = None
 
     def tearDown(self) -> None:
         common.SCHEMA_COUNT.clear()
@@ -227,7 +229,7 @@ class TestChangeStreams(unittest.TestCase):
                     '_id': 'id11',
                     'key1': 1,
                     'key2': 'abc',
-                    'key3': {'a': 1, 'b': datetime(2020, 4, 10, 14, 50, 55, 0)}
+                    'key3': {'a': 1, 'b': datetime(2020, 4, 10, 14, 50, 55, 0, tzinfo=pytz.utc)}
                 }
             }).return_value,
             Mock(spec_set=ChangeStream, return_value={
@@ -316,10 +318,9 @@ class TestChangeStreams(unittest.TestCase):
         self.assertEqual({
             'bookmarks': {
                 'mydb-stream1': {
-                    'token':
-                        {
-                            '_data': 'token6'
-                        },
+                    'token': {
+                        '_data': 'token6'
+                    },
                 },
                 'mydb-stream2': {
                     'token': {
@@ -351,7 +352,7 @@ class TestChangeStreams(unittest.TestCase):
         ], [msg.__class__.__name__ for msg in messages])
 
         self.assertListEqual([
-            {'_id': 'id11', 'document': {'_id': 'id11', 'key1': 1, 'key2': 'abc','key3': {'a': 1, 'b': '2020-04-10T11:50:55.000000Z'}}, common.SDC_DELETED_AT: None},
+            {'_id': 'id11', 'document': {'_id': 'id11', 'key1': 1, 'key2': 'abc','key3': {'a': 1, 'b': '2020-04-10T14:50:55.000000Z'}}, common.SDC_DELETED_AT: None},
             {'_id': 'id13', 'document': {'_id': 'id13', 'key2': 'eeeeef'}, common.SDC_DELETED_AT: None},
             {'_id': 'id21', 'document':{'_id': 'id21', 'key6': 12, 'key10': 'abc','key11': [1,2,3, '10']}, common.SDC_DELETED_AT: None},
             {'_id': 'id22', 'document': {'_id': 'id22'}, common.SDC_DELETED_AT: '2020-05-05T00:00:00.000000Z'},

--- a/tests/sync_strategies/test_change_streams.py
+++ b/tests/sync_strategies/test_change_streams.py
@@ -311,7 +311,7 @@ class TestChangeStreams(unittest.TestCase):
         mock_db.watch.return_value = mock_watch
         type(mock_db).name = PropertyMock(return_value='mydb')
 
-        change_streams.sync_database(mock_db, streams, state)
+        change_streams.sync_database(mock_db, streams, state, 1, 1)
 
         self.assertEqual({
             'bookmarks': {
@@ -343,19 +343,19 @@ class TestChangeStreams(unittest.TestCase):
 
         self.assertListEqual([
             'RecordMessage',  # insert
+            'RecordMessage',  # update
             'RecordMessage',  # insert
             'RecordMessage',  # delete
             'RecordMessage',  # insert
             'StateMessage',
-            'RecordMessage',  # update
         ], [msg.__class__.__name__ for msg in messages])
 
         self.assertListEqual([
             {'_id': 'id11', 'document': {'_id': 'id11', 'key1': 1, 'key2': 'abc','key3': {'a': 1, 'b': '2020-04-10T11:50:55.000000Z'}}, common.SDC_DELETED_AT: None},
+            {'_id': 'id13', 'document': {'_id': 'id13', 'key2': 'eeeeef'}, common.SDC_DELETED_AT: None},
             {'_id': 'id21', 'document':{'_id': 'id21', 'key6': 12, 'key10': 'abc','key11': [1,2,3, '10']}, common.SDC_DELETED_AT: None},
             {'_id': 'id22', 'document': {'_id': 'id22'}, common.SDC_DELETED_AT: '2020-05-05T00:00:00.000000Z'},
             {'_id': 'id13', 'document': {'_id': 'id13', 'key3': '2020-05-05T00:00:00.000000Z'}, common.SDC_DELETED_AT: None},
-            {'_id': 'id13', 'document': {'_id': 'id13', 'key2': 'eeeeef' }, common.SDC_DELETED_AT: None},
         ], [msg.record for msg in messages if isinstance(msg, RecordMessage)])
 
         self.assertEqual(common.COUNTS['mydb-stream1'], 3)

--- a/tests/sync_strategies/test_common.py
+++ b/tests/sync_strategies/test_common.py
@@ -80,9 +80,28 @@ class TestRowToSchemaMessage(unittest.TestCase):
         with self.assertRaises(UnsupportedKeyTypeException):
             common.class_to_string('a', 'random type')
 
-    def test_transform_value_with_datetime_should_return_utc_formatted_date(self):
+    def test_transform_value_with_naive_datetime_should_return_utc_formatted_date(self):
+        import tzlocal
+        import pytz
+
         date = datetime(2020, 5, 13, 15, 00, 00)
-        self.assertEqual('2020-05-13T12:00:00.000000Z', common.transform_value(date, None))
+        output = common.transform_value(date, None)
+
+        local_tz = tzlocal.get_localzone()
+        dt = local_tz.localize(date).astimezone(pytz.UTC)
+
+        fmt = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+        self.assertEqual(dt.strftime(fmt), output)
+
+    def test_transform_value_with_datetime_should_return_utc_formatted_date(self):
+        import tzlocal
+        import pytz
+
+        amsterdam = pytz.timezone('Europe/Amsterdam')
+        date = amsterdam.localize(datetime(2020, 5, 13, 15, 00, 00))
+
+        self.assertEqual('2020-05-13T13:00:00.000000Z', common.transform_value(date, None))
 
     def test_transform_value_with_bytes_should_return_decoded_string(self):
         b = b'Pythonnnn'


### PR DESCRIPTION
# Problem

Log based implementation use some parameters whose values are hardcoded.

1. change stream [watch](https://github.com/transferwise/pipelinewise-tap-mongodb/blob/65ec7cf52fc59ec1e45bda11c93e7857de561361/tap_mongodb/sync_strategies/change_streams.py#L106) method waits by default 5min for new changes before exiting. 


2. The cursor created [here](https://github.com/transferwise/pipelinewise-tap-mongodb/blob/65ec7cf52fc59ec1e45bda11c93e7857de561361/tap_mongodb/sync_strategies/change_streams.py#L49) gets killed by the server because the processing in between every usage of the cursor takes 10min, which is how long the server waits before killing the idle cursors.


3. the `test & coverage` CI step doesn't make CI fail when tests don't pass

# Solution

Make parameters configurable, with default values.

1. `await_time_ms` would control how long the log_based method would wait for new change streams before stopping, default is 1000ms=1s which is the default anyway in the server.

2. `update_buffer_size` would control how many update operation we should keep in the memory before having to make a call to `find` to get the documents from the server. We hope that this can fix the problem of idle cursors if the value of the buffer is small, otherwise, having a batching mode on the cursor is the next best solution.
The default value is 1 as agreed with the team, i.e every detected update will be sent to stout right away.   

3. switched library to pytest's plugin cov
-> detected some timezone issues in tests and got them fixed.


# QA steps
 - [x] automated tests passing
 - [x] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
