### PR TITLE
add uri connexion to mongodb

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,16 @@ Create json file called `config.json`, with the following contents:
   "database": "<database name to sync from>"
 }
 ```
+
+or
+
+```json
+{
+  "uri": "<connexion URI string>", 
+  "database": "<database name to sync from>"
+}
+```
+
 The following parameters are optional for your config file:
 
 | Name | Type | Default value| Description |

--- a/README.md
+++ b/README.md
@@ -33,7 +33,9 @@ or
 ```json
 {
   "uri": "<connexion URI string>", 
-  "database": "<database name to sync from>"
+  "database": "<database name to sync from>",
+  "user": "<username>",
+  "auth_database": "<database name to authenticate on>"
 }
 ```
 

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -32,7 +32,9 @@ REQUIRED_CONFIG_KEYS = [
 
 REQUIRED_URI_CONFIG_KEYS = [
     'uri',
-    'database'
+    'database',
+    'user',
+    'auth_database'
 ]
 
 LOG_BASED_METHOD = 'LOG_BASED'


### PR DESCRIPTION
# Problem
Could not connect to my mongo ATLAS server with error : ([Errno 8] nodename nor servname provided, or not known)
I can only connect with a URI like this one : mongodb+srv://<user>:<password>@xxx.yyy.gcp.mongodb.net/<db_auth>?retryWrites=true&w=majority


# Solution
config.json accept args host, user, password ....... or only the URI.
If URI is in config then required parameters are only Uri and database.
If not, then it's like before.


# QA steps
 - [ ] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
