### PR TITLE
AP-1039 CI - Add python matrix to test against 3.6 -> 3.8

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,12 +12,18 @@ env:
 jobs:
   lint_and_test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: [ 3.6, 3.7, 3.8 ]
 
     steps:
       - name: Checkout repository
         uses: actions/checkout@v2
+
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
         with:
-          fetch-depth: 0
+          python-version: ${{ matrix.python-version }}
 
       - name: Setup virtual env
         run: |


### PR DESCRIPTION
# Problem
We're not testing against python 3.6, 3.7, 3.8 to ensure the code works with these versions

# Solution
Add matrix to the CI


# QA steps
 - [x] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
