### PR TITLE
Add support for connection strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,6 @@ Create json file called `config.json`, with the following contents:
   "password": "<password>",
   "user": "<username>",
   "host": "<host ip address>",
-  "port": "<port>",
   "auth_database": "<database name to authenticate on>",
   "database": "<database name to sync from>"
 }
@@ -31,6 +30,8 @@ The following parameters are optional for your config file:
 
 | Name | Type | Default value| Description |
 | -----|------|--------|------------ |
+| `srv` | Boolean | false | uses a `mongodb+srv` protocol to connect. Disables the usage of `port` argument if set to `True` |
+| `port` | Integer | false | Connection port. Required if a non-srv connection is being used.  |
 | `replica_set` | string | null | name of replica set |
 | `ssl` | Boolean | false | can be set to true to connect using ssl |
 | `verify_mode` | Boolean | true | Default SSL verify mode |

--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -251,7 +251,7 @@ def main_impl():
     """
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
-    srv = config.get('srv') == True
+    srv = config.get('srv') is True
 
     if not srv:
         args = utils.parse_args(REQUIRED_CONFIG_KEYS_NON_SRV)

--- a/tests/test_connection_string.py
+++ b/tests/test_connection_string.py
@@ -4,66 +4,66 @@ from tap_mongodb import get_connection_string
 
 
 class TestConnectionString(unittest.TestCase):
-  def setUp(self):
-    self.config = {
-      "host": "dummy-host",
-      "user": "dummy-user",
-      "password": "dummy-password",
-      "auth_database": "dummy-auth-database",
-      "database": "dummy-databse",
-      "port": "2017"
-    }
+    def setUp(self):
+        self.config = {
+            "host": "dummy-host",
+            "user": "dummy-user",
+            "password": "dummy-password",
+            "auth_database": "dummy-auth-database",
+            "database": "dummy-databse",
+            "port": "2017"
+        }
 
-  def test_minimal_config(self):
-    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
-    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
+    def test_minimal_config(self):
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
 
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_default_string, connection_string)
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
 
-    self.config["srv"] = "true"
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_srv_string, connection_string)
-
-
-  def test_replica_set_config(self):
-    self.config["replica_set"] = "dummy-replica-set"
-
-    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
-    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
-
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_default_string, connection_string)
-
-    self.config["srv"] = "true"
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_srv_string, connection_string)
+        self.config["srv"] = "true"
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)
 
 
-  def test_strict_ssl_config(self):
-    self.config["ssl"] = "true"
+    def test_replica_set_config(self):
+        self.config["replica_set"] = "dummy-replica-set"
 
-    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
-    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
 
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_default_string, connection_string)
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
 
-    self.config["srv"] = "true"
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_srv_string, connection_string)
+        self.config["srv"] = "true"
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)
 
 
-  def test_weak_ssl_config(self):
-    self.config["ssl"] = "true"
-    self.config["verify_mode"] = "false"
+    def test_strict_ssl_config(self):
+        self.config["ssl"] = "true"
 
-    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
-    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
 
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_default_string, connection_string)
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
 
-    self.config["srv"] = "true"
-    connection_string = get_connection_string(self.config)
-    self.assertEqual(expected_srv_string, connection_string)
+        self.config["srv"] = "true"
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)
+
+
+    def test_weak_ssl_config(self):
+        self.config["ssl"] = "true"
+        self.config["verify_mode"] = "false"
+
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
+
+        self.config["srv"] = "true"
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)

--- a/tests/test_connection_string.py
+++ b/tests/test_connection_string.py
@@ -1,0 +1,69 @@
+import unittest
+
+from tap_mongodb import get_connection_string
+
+
+class TestConnectionString(unittest.TestCase):
+  def setUp(self):
+    self.config = {
+      "host": "dummy-host",
+      "user": "dummy-user",
+      "password": "dummy-password",
+      "auth_database": "dummy-auth-database",
+      "database": "dummy-databse",
+      "port": "2017"
+    }
+
+  def test_minimal_config(self):
+    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
+    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database"
+
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_default_string, connection_string)
+
+    self.config["srv"] = "true"
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_srv_string, connection_string)
+
+
+  def test_replica_set_config(self):
+    self.config["replica_set"] = "dummy-replica-set"
+
+    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
+    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&replicaSet=dummy-replica-set"
+
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_default_string, connection_string)
+
+    self.config["srv"] = "true"
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_srv_string, connection_string)
+
+
+  def test_strict_ssl_config(self):
+    self.config["ssl"] = "true"
+
+    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_default_string, connection_string)
+
+    self.config["srv"] = "true"
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_srv_string, connection_string)
+
+
+  def test_weak_ssl_config(self):
+    self.config["ssl"] = "true"
+    self.config["verify_mode"] = "false"
+
+    expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+    expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_default_string, connection_string)
+
+    self.config["srv"] = "true"
+    connection_string = get_connection_string(self.config)
+    self.assertEqual(expected_srv_string, connection_string)


### PR DESCRIPTION
# Problem
In special cases like using Atlas, we have to use the connection string provided by them. This limitation comes from PyMongo which requires a port number for standard MongoDB connections but crashes when we pass a port and use a SRV connection.

# Solution

The solution I am proposing is to add the option to use a connection string instead of separate arguments. https://pymongo.readthedocs.io/en/stable/atlas.html

Aside from that, this method provides people with much more flexibility in the connection.

# QA steps

- Connected to an Atlas server using the connection string
- Connected to a local MongoDB installation using the parameters
 
# Risks

N/A

# Rollback steps
 - Revert this branch
