### PR TITLE
Pin dnspython version to 2.1.*

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ setup(name='pipelinewise-tap-mongodb',
           'pymongo==3.12.*',
           'tzlocal==2.1.*',
           'terminaltables==3.1.*',
-          'dnspython>=2.0,<2.2',
+          'dnspython==2.1.*',
       ],
       extras_require={
           'dev': [


### PR DESCRIPTION
# Problem
`dnspython` requirement is too loose

# Solution
Pin `dnspython` requirement to a specific minor version


# QA steps
 - [ ] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
