### PR TITLE
fix: Replace "-" with "_" in stream names to fix schema parsing in ppw targets

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 1.3.1
+   * Replace "-" with "_" in stream names to fix schema parsing in ppw targets
+
+
 ## 1.3.0
    * Support connection to MongoAtlas using `mongodb+srv` protocol   
    * Pin dnspython to `2.1.*`

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -33,10 +33,16 @@ def calculate_destination_stream_name(stream: Dict) -> str:
     Returns: str holding the stream name
     """
     s_md = metadata.to_map(stream['metadata'])
-    if INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME:
-        return f"{s_md.get((), {}).get('database-name')}-{stream['stream']}"
 
-    return stream['stream']
+    # "-" in names breaks pipelinewise logic of schema parsing in ppw targets (ex target-bigquery)
+    stream_name = stream['stream'].replace('-', '_')
+
+    if INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME:
+        database_name = s_md.get((), {}).get('database-name').replace('-', '_')
+
+        return f"{database_name}-{stream_name}"
+
+    return stream_name
 
 
 def get_stream_version(tap_stream_id: str, state: Dict) -> int:

--- a/tests/sync_strategies/test_common.py
+++ b/tests/sync_strategies/test_common.py
@@ -35,6 +35,25 @@ class TestRowToSchemaMessage(unittest.TestCase):
             constant_mock.return_value = True
             self.assertEqual('myDb-myStream', common.calculate_destination_stream_name(stream))
 
+    def test_calculate_destination_stream_name_with_dashes_and_with_include_schema_True(self):
+        """
+
+        """
+        stream = {
+            'stream': 'my-stream-with-dashes',
+            'metadata': [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "my-db-with-dashes",
+                    }
+                }
+            ]
+        }
+        with patch('tap_mongodb.common.INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME') as constant_mock:
+            constant_mock.return_value = True
+            self.assertEqual('my_db_with_dashes-my_stream_with_dashes', common.calculate_destination_stream_name(stream))
+
     def test_calculate_destination_stream_name_with_include_schema_False(self):
         """
 
@@ -52,6 +71,24 @@ class TestRowToSchemaMessage(unittest.TestCase):
         }
         common.INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME = False
         self.assertEqual('myStream', common.calculate_destination_stream_name(stream))
+
+    def test_calculate_destination_stream_name_with_dashes_and_with_include_schema_False(self):
+        """
+
+        """
+        stream = {
+            'stream': 'my-stream-with-dashes',
+            'metadata': [
+                {
+                    "breadcrumb": [],
+                    "metadata": {
+                        "database-name": "my-db-with-dashes",
+                    }
+                }
+            ]
+        }
+        common.INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME = False
+        self.assertEqual('my_stream_with_dashes', common.calculate_destination_stream_name(stream))
 
     def test_get_stream_version_with_none_version_returns_new_version(self):
 


### PR DESCRIPTION
# Problem
If database name or table name contains "-" it breaks schema parsing logic in ppw targets, ex `pipelinewise-target-bigquery`

See: https://github.com/jmriego/pipelinewise-target-bigquery/blob/master/target_bigquery/stream_utils.py#L114

# Solution
Replace "-" with "_" in database and table name when constructing stream name


# QA steps
 - [x] automated tests passing
 - [ ] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
