### PR TITLE
add uri param and allow booleans in config

### DIFF
--- a/tap_mongodb/__init__.py
+++ b/tap_mongodb/__init__.py
@@ -253,11 +253,16 @@ def get_connection_string(config: Dict):
 
     Returns: A MongoClient connection string
     """
-    srv = config.get('srv') == 'true'
+    uri = config.get('uri')
+    if uri is not None:
+        LOGGER.debug('using uri %s', uri)
+        return uri
+
+    srv = config.get('srv') is True or config.get('srv') == 'true'
 
     # Default SSL verify mode to true, give option to disable
-    verify_mode = config.get('verify_mode', 'true') == 'true'
-    use_ssl = config.get('ssl') == 'true'
+    verify_mode = config.get('verify_mode') is True or config.get('verify_mode', 'true') == 'true'
+    use_ssl = config.get('ssl') is True or config.get('ssl') == 'true'
 
     connection_query = {
         'readPreference': 'secondaryPreferred',
@@ -291,7 +296,7 @@ def main_impl():
     """
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
     config = args.config
-    srv = config.get('srv') == 'true'
+    srv = config.get('srv') is True or config.get('srv') == 'true'
 
     if not srv:
         args = utils.parse_args(REQUIRED_CONFIG_KEYS_NON_SRV)
@@ -305,7 +310,7 @@ def main_impl():
                 client.server_info().get('version', 'unknown'))
 
     common.INCLUDE_SCHEMAS_IN_DESTINATION_STREAM_NAME = \
-        (config.get('include_schemas_in_destination_stream_name') == 'true')
+        (config.get('include_schemas_in_destination_stream_name') is True or config.get('include_schemas_in_destination_stream_name') == 'true')
 
     if args.discover:
         do_discover(client, config)

--- a/tests/test_connection_string.py
+++ b/tests/test_connection_string.py
@@ -53,6 +53,19 @@ class TestConnectionString(unittest.TestCase):
         connection_string = get_connection_string(self.config)
         self.assertEqual(expected_srv_string, connection_string)
 
+    def test_strict_ssl_config_bools(self):
+        self.config["ssl"] = True
+
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true"
+
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
+
+        self.config["srv"] = True
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)
+
 
     def test_weak_ssl_config(self):
         self.config["ssl"] = "true"
@@ -67,3 +80,25 @@ class TestConnectionString(unittest.TestCase):
         self.config["srv"] = "true"
         connection_string = get_connection_string(self.config)
         self.assertEqual(expected_srv_string, connection_string)
+
+    def test_weak_ssl_config_bools(self):
+        self.config["ssl"] = True
+        self.config["verify_mode"] = False
+
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+        expected_srv_string = "mongodb+srv://dummy-user:dummy-password@dummy-host/dummy-databse?readPreference=secondaryPreferred&authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)
+
+        self.config["srv"] = True
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_srv_string, connection_string)
+
+    def test_uri_config(self):
+        self.config["uri"] = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+
+        expected_default_string = "mongodb://dummy-user:dummy-password@dummy-host:2017/dummy-databse?authSource=dummy-auth-database&tls=true&tlsAllowInvalidCertificates=true"
+
+        connection_string = get_connection_string(self.config)
+        self.assertEqual(expected_default_string, connection_string)


### PR DESCRIPTION
# Problem
See https://github.com/transferwise/pipelinewise-tap-mongodb/issues/75


# Solution
Do boolean value comparisons against boolean objects, in addition to lower case string values. Also added a param to accept a fully constructed MongoDB URI to allow easier work arounds for similar issues in the future.


# QA steps
 - [X] automated tests passing
 - [X] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch
