### PR TITLE
Add full refresh

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -110,3 +110,6 @@ catalog*.json
 
 # Jetbrains .idea
 .idea
+
+# vscode .vscode
+.vscode

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ __pycache__/
 # C extensions
 *.so
 
+# Mac
+.DS_Store
+
 # Distribution / packaging
 .Python
 env/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.3.1
+Added flag to trigger full table load when performing LOG_BASED replication with no previous state token present.
+
 ## 1.3.0
    * Support connection to MongoAtlas using `mongodb+srv` protocol   
    * Pin dnspython to `2.1.*`

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The following parameters are optional for your config file:
 | `include_schemas_in_destination_stream_name` | Boolean |false  | forces the stream names to take the form `<database_name>-<collection_name>` instead of `<collection_name>`|
 | `update_buffer_size` | int | 1 | [LOG_BASED] The size of the buffer that holds detected update operations in memory, the buffer is flushed once the size is reached |
 | `await_time_ms` | int | 1000 | [LOG_BASED] The maximum amount of time in milliseconds the loge_base method waits for new data changes before exiting. |
+| `full_load_on_empty_state` | bool | false | [LOG_BASED] A flag which forces full load when no previous token is found in state.|
 
 All of the above attributes are required by the tap to connect to your mongo instance. 
 here is a [sample configuration file](./sample_config.json).

--- a/sample_config.json
+++ b/sample_config.json
@@ -9,5 +9,6 @@
   "verify_mode": "<SSL verify mode | optional, default 'true'>",
   "ssl": "<enable SSL | optional>",
   "update_buffer_size": "<int>",
-  "await_time_ms": "<int>"
+  "await_time_ms": "<int>",
+  "full_load_on_empty_state": "<bool>"
 }

--- a/tap_mongodb/config_utils.py
+++ b/tap_mongodb/config_utils.py
@@ -1,6 +1,6 @@
 from typing import Dict
 
-from tap_mongodb.errors import InvalidAwaitTimeError, InvalidUpdateBufferSizeError
+from tap_mongodb.errors import InvalidAwaitTimeError, InvalidLogBasedFullLoadOnEmptyState, InvalidUpdateBufferSizeError
 from tap_mongodb.sync_strategies import change_streams
 
 
@@ -38,3 +38,9 @@ def validate_config(config: Dict) -> None:
         if await_time_ms <= 0:
             raise InvalidAwaitTimeError(
                 await_time_ms, 'time must be > 0')
+
+    if 'full_load_on_empty_state' in config:
+        full_load_on_empty_state = config['full_load_on_empty_state']
+        
+        if full_load_on_empty_state.lower() not in ['true', 'false']:
+            raise InvalidLogBasedFullLoadOnEmptyState(full_load_on_empty_state, 'expected string boolean.')

--- a/tap_mongodb/errors.py
+++ b/tap_mongodb/errors.py
@@ -39,3 +39,9 @@ class InvalidAwaitTimeError(Exception):
     def __init__(self, time_ms, reason):
         msg = f"Invalid await time {time_ms}! {reason}"
         super().__init__(msg)
+
+class InvalidLogBasedFullLoadOnEmptyState(Exception):
+    """Raised if the given log based full load on empty state in log_based invalid"""
+    def __init__(self, full_load_on_empty_state, reason) -> None:
+        msg = f"Invalid full load on empty state arg {full_load_on_empty_state}! {reason}"
+        super().__init__(msg)


### PR DESCRIPTION
# Problem
When running `log_based` the tap begins processing at the current point-in-time or at the last known state. There is no way to capture previous records because a change in load type resets state.

# Solution
Create a flag that triggers `full_load` functionality

# QA steps
 - [ ] automated tests passing
 - [x] manual QA steps passing (list below)

 
# Risks
I'm not certain that the process will successfully transition from `full_load` to `log_based`, records may be left behind that were created/updated during the `full_load` but before the `log_based` processing begins.

# Rollback steps
 - Revert this branch
