### PR TITLE
Switch to MongoDB server 5.0 compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,14 @@
 # Changelog
 
+## 1.5.0
+   * Switch to MongoDB server 5.0 compatibility
+
 ## 1.4.0
    * Bump `pymongo` from `3.12.*` to `4.7.*`
 
 
 ## 1.3.0
-   * Support connection to MongoAtlas using `mongodb+srv` protocol   
+   * Support connection to MongoAtlas using `mongodb+srv` protocol
    * Pin dnspython to `2.1.*`
    * Bump `pymongo` from `3.10.*` to `3.12.*`
    * Bump `tzlocal` from `2.0.*` to `2.1.*`
@@ -24,7 +27,7 @@ Make 2 LOG_BASED parameters configurable:
 * `update_buffer_size` would control how many update operation we should keep in the memory before having to make a call to `find` operation to get the documents from the server. The default value is 1, i.e every detected update will be sent to stdout right away.
 
 ## 1.0.1
-   * Fix case where resume tokens has extra properties that are not json serializable by saving `_data` only. 
+   * Fix case where resume tokens has extra properties that are not json serializable by saving `_data` only.
 
 ## 1.0.0
    * This is a fork of [Singer's tap-mongodb version 2.0.0](https://github.com/singer-io/tap-mongodb).

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,8 @@
-version: "3"
-
 services:
   db:
     container_name: "tap_mongodb_dev"
-    image: "mongo:4.2-bionic"
+    image: "mongo:5.0.26-focal"
+
     ports:
       - 27017:27017
     environment:

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open('README.md', 'r') as fh:
     long_desc = fh.read()
 
 setup(name='pipelinewise-tap-mongodb',
-      version='1.4.0',
+      version='1.5.0',
       description='Singer.io tap for extracting data from MongoDB - Pipelinewise compatible',
       long_description=long_desc,
       long_description_content_type='text/markdown',

--- a/tap_mongodb/sync_strategies/common.py
+++ b/tap_mongodb/sync_strategies/common.py
@@ -103,7 +103,7 @@ def string_to_class(str_value: str, type_value: str) -> Any:
     """
 
     conversion = {
-        'UUID': uuid.UUID,
+        'UUID': lambda val: bson.Binary.from_uuid(uuid.UUID(val)),
         'datetime': singer.utils.strptime_with_tz,
         'int': int,
         'Int64': bson.int64.Int64,
@@ -169,6 +169,7 @@ def transform_value(value: Any, path) -> Any:
         datetime.datetime: lambda val, _: class_to_string(val, 'datetime'),
         bson.decimal128.Decimal128: lambda val, _: val.to_decimal(),
         bson.regex.Regex: lambda val, _: dict(pattern=val.pattern, flags=val.flags),
+        bson.binary.Binary: lambda val, _: class_to_string(val, 'bytes'),
         bson.code.Code: lambda val, _: dict(value=str(val), scope=str(val.scope)) if val.scope else str(val),
         bson.dbref.DBRef: lambda val, _: dict(id=str(val.id), collection=val.collection, database=val.database),
     }

--- a/tests/sync_strategies/test_common.py
+++ b/tests/sync_strategies/test_common.py
@@ -114,7 +114,7 @@ class TestRowToSchemaMessage(unittest.TestCase):
 
     def test_string_to_class_with_UUID(self):
         uid = '123e4567-e89b-12d3-a456-426652340000'
-        self.assertEqual(uuid.UUID(uid), common.string_to_class(uid, 'UUID'))
+        self.assertEqual(bson.Binary.from_uuid(uuid.UUID(uid)), common.string_to_class(uid, 'UUID'))
 
     def test_string_to_class_with_formatted_utc_datetime(self):
         dt = '2020-05-10T12:01:50.000000Z'


### PR DESCRIPTION
## Context
[AP-1693](https://transferwise.atlassian.net/browse/AP-1693)
PipelineWise to prefer TLS connections, tap-mongo only supported from v 5.0

# QA steps
 - [x] automated tests passing
 - [x] manual QA steps passing (list below)

 
# Risks


# Rollback steps
 - Revert this branch


[AP-1693]: https://transferwise.atlassian.net/browse/AP-1693?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ